### PR TITLE
Fix Swagger $ref schema error

### DIFF
--- a/src/ischema.ts
+++ b/src/ischema.ts
@@ -25,6 +25,7 @@ export const toSwagger = (iSchema: ISchema | joi.Schema): any => {
   if ($ref && $ref[Tags.tagDefinitionName]) {
     description = $ref[Tags.tagDefinitionDescription];
     $ref = "#/definitions/" + $ref[Tags.tagDefinitionName];
+    return {$ref, description};
   }
   let result = {items, type: iSchema["type"] || "object", $ref, description};
   if (iSchema["required"]) {


### PR DESCRIPTION
Generated Swagger schema fails validation due to error generating ref sub-schema 'Structural error: siblings values not allowed alongside $refs'

Can be checked here: https://editor.swagger.io